### PR TITLE
124 plnmodels is not compatible with r 41

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: PLNmodels
 Title: Poisson Lognormal Models
-Version: 1.2.0
+Version: 1.2.1
 Authors@R: c(
   person("Julien", "Chiquet", role = c("aut", "cre"), email = "julien.chiquet@inrae.fr",
       comment = c(ORCID = "0000-0002-3629-3429")),
@@ -26,7 +26,7 @@ License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
-Depends: R (>= 3.4)
+Depends: R (>= 3.6)
 LazyData: true
 biocViews:
 Imports: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Current version
+
+* fix use of native pipe to ensure compatibility with R 3.6 (merge PR #125, fix #124)
+
 # PLNmodels 1.2.0 (2024-03-05)
 
 * new feature: ZIPLN (PLN with zero inflation) for standard PLN and PLN Network

--- a/R/ZIPLN.R
+++ b/R/ZIPLN.R
@@ -93,9 +93,9 @@ ZIPLN_param <- function(
 ) {
 
   covariance <- match.arg(covariance)
-  if (covariance == "fixed") stopifnot("Omega must be provied for fixed covariance" = inherits(Omega, "matrix") | inherits(Omega, "Matrix")) |> try()
+  if (covariance == "fixed") stopifnot("Omega must be provied for fixed covariance" = inherits(Omega, "matrix") | inherits(Omega, "Matrix")) %>% try()
   if (inherits(Omega, "matrix") | inherits(Omega, "Matrix")) covariance <- "fixed"
-  if (covariance == "sparse") stopifnot("You should provide a positive penalty when chosing 'sparse' covariance" = penalty > 0) |> try()
+  if (covariance == "sparse") stopifnot("You should provide a positive penalty when chosing 'sparse' covariance" = penalty > 0) %>% try()
   if (penalty > 0) covariance <- "sparse"
   if (!is.null(inception)) stopifnot(isZIPLNfit(inception))
 


### PR DESCRIPTION
Replace native pipe `|>` with magrittr's pipe `%>%` to ensure compatibility with R 3.6. Fix #124 