### PR TITLE
Fix PLNnetwork crash issues from glasso

### DIFF
--- a/R/PLNfamily-class.R
+++ b/R/PLNfamily-class.R
@@ -72,27 +72,24 @@ PLNfamily <-
         } else {
           nullModel <- NULL
         }
-        for (i in seq_along(self$models)) {
-          model <- self$models[[i]]
-          tryCatch(
-            {
-              model$postTreatment(
-                self$responses,
-                self$covariates,
-                self$offsets,
-                self$weights,
-                config_post = config_post,
-                config_optim = config_optim,
-                nullModel = nullModel
-              )
-            },
-            error = function(e) {
-              warning(paste("Post-treatment failed for model", i, ":", e$message, "\nTruncating model family to models 1 to", i - 1))
-              self$models <- self$models[1:(i - 1)]
-              break
-            }
-          )
-        }
+        tryCatch({
+          for (i in seq_along(self$models)) {
+            model <- self$models[[i]]
+            model$postTreatment(
+              self$responses,
+              self$covariates,
+              self$offsets,
+              self$weights,
+              config_post = config_post,
+              config_optim = config_optim,
+              nullModel = nullModel
+            )
+          }
+        },
+        error = function(e) {
+          warning(paste("Post-treatment failed for model", i, ":", e$message, "\nTruncating model family to models 1 to", i - 1))
+          self$models <- self$models[1:(i - 1)]
+        })
       },
 
       ## %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/R/PLNfamily-class.R
+++ b/R/PLNfamily-class.R
@@ -72,16 +72,26 @@ PLNfamily <-
         } else {
           nullModel <- NULL
         }
-        for (model in self$models)
-          model$postTreatment(
-            self$responses,
-            self$covariates,
-            self$offsets,
-            self$weights,
-            config_post=config_post,
-            config_optim=config_optim,
-            nullModel = nullModel
-        )
+        for (i in seq_along(self$models)) {
+          model <- self$models[[i]]
+          tryCatch(
+            {
+              model$postTreatment(
+                self$responses,
+                self$covariates,
+                self$offsets,
+                self$weights,
+                config_post = config_post,
+                config_optim = config_optim,
+                nullModel = nullModel
+              )
+            },
+            error = function(e) {
+              warning(paste("Post-treatment failed for model", i, ":", e$message, "\nTruncating model family to models 1 to", i - 1))
+              self$models <- self$models[1:(i - 1)]
+            }
+          )
+        }
       },
 
       ## %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/R/PLNfamily-class.R
+++ b/R/PLNfamily-class.R
@@ -89,6 +89,7 @@ PLNfamily <-
             error = function(e) {
               warning(paste("Post-treatment failed for model", i, ":", e$message, "\nTruncating model family to models 1 to", i - 1))
               self$models <- self$models[1:(i - 1)]
+              break
             }
           )
         }

--- a/R/PLNnetworkfamily-class.R
+++ b/R/PLNnetworkfamily-class.R
@@ -120,6 +120,16 @@ Networkfamily <- R6Class(
     },
 
     ## %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    ## Post treatment --------------------
+    #' @description Update fields after optimization
+    #' @param config_post a list for controlling the post-treatments (optional bootstrap, jackknife, R2, etc.).
+    #' @param config_optim a list for controlling the optimization parameters used during post_treatments
+    postTreatment = function(config_post, config_optim) {
+      super$postTreatment(config_post, config_optim)
+      private$params <- self$penalties[seq_along(self$models)]
+    },
+
+    ## %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     ## Extractors ------------------------
     #' @description Extract the regularization path of a [`Networkfamily`]
     #' @param precision Logical. Should the regularization path be extracted from the precision matrix Omega (`TRUE`, default) or from the variance matrix Sigma (`FALSE`)
@@ -432,7 +442,13 @@ PLNnetworkfamily <- R6Class(
         myPLN <- PLNnetworkfamily$new(self$penalties, data, control)
         myPLN$optimize(data, control$config_optim)
         nets <- do.call(cbind, lapply(myPLN$models, function(model) {
-          as.matrix(model$latent_network("support"))[upper.tri(diag(private$p))]
+          # If Omega is null, glasso diverged on the first iteration, so the network is completely unstable
+          if (is.null(model$model_par$Omega)) {
+            support <- matrix(0, nrow = private$p, ncol = private$p)
+          } else {
+            support <- as.matrix(model$latent_network("support"))
+          }
+          support[upper.tri(diag(private$p))]
         }))
         nets
       }, mc.cores = getOption("mc.cores", 1L))
@@ -595,7 +611,12 @@ ZIPLNnetworkfamily <- R6Class(
         myPLN$optimize(data, control$config_optim)
 
         nets <- do.call(cbind, lapply(myPLN$models, function(model) {
-          as.matrix(model$latent_network("support"))[upper.tri(diag(private$p))]
+          if (is.null(model$model_par$Omega)) {
+            support <- matrix(0, nrow = private$p, ncol = private$p)
+          } else {
+            support <- as.matrix(model$latent_network("support"))
+          }
+          support[upper.tri(diag(private$p))]
         }))
         nets
       }, mc.cores = getOption("mc.cores", 1L))


### PR DESCRIPTION
## The problem
### Short version
When some sparsity parameters are too small, `PLNnetwork()` crashes completely and returns nothing. It can take quite a while to reach the crash point and there is not a straightforward way to select sparsities or the `min_ratio` to avoid this issue. All that you get back is an error message like the following:
```
Error in value[[3L]](cond) : 
  Error in `colnames<-`(`*tmp*`, value = c("ENSDARG00000044056", "ENSDARG00000012763", : attempt to set 'colnames' on an object with less than two dimensions
```

Similarly, even if the `PLNnetworkfamily` fits successfully, the same issue can occur when running `stability_selection()`, which gives a slightly different error:
```
Error in h(simpleError(msg, call)) : 
  error in evaluating the argument 'x' in selecting a method for function 'as.matrix': invalid 'nrow' value (too large or NA)
```

### Long version
When the sparsity for a `PLNnetworkfit` is sufficiently small, `glassoFast` diverges on the first iteration of VEM and returns `NA`s. This causes a `PLNnetworkfit` to break out of [the loop](https://github.com/cole-trapnell-lab/PLNmodels/blob/66e1a545735ee57c5d0fb4640e36a279066b1265/R/PLNnetworkfit-class.R#L78-L84) before `Omega` is set:
```R
  while (!cond) {
    iter <- iter + 1
    if (config$trace > 1) cat("", iter)
    ## CALL TO GLASSO TO UPDATE Omega
    glasso_out <- glassoFast::glassoFast(private$Sigma, rho = self$penalty * self$penalty_weights)
    if (anyNA(glasso_out$wi)) break
    private$Omega <- args$params$Omega <- Matrix::symmpart(glasso_out$wi)
    ...
  }
```

This doesn't stop `myPLN$optimize()` from running for the rest of the `PLNnetworkfamily`. However, it fails during post-treatments because each `PLNnetworkfit` inherits its post-treatment method from `PLNfit`, which errors at the [following line](https://github.com/cole-trapnell-lab/PLNmodels/blob/66e1a545735ee57c5d0fb4640e36a279066b1265/R/PLNfit-class.R#L493) because `Omega` is `NULL`:
```R
rownames(private$Omega) <- colnames(private$Omega) <- colnames(responses)
```

This causes the entire call to `PLNnetwork` to crash without returning anything, even if the rest of the network family is fine.

This issue can also come up when running `myPLN$stability_selection()`, even if it does not cause an issue when fitting the `PLNnetworkfamily` on the full data. Here, the error is caused when [calculating the stability across samples](https://github.com/cole-trapnell-lab/PLNmodels/blob/66e1a545735ee57c5d0fb4640e36a279066b1265/R/PLNnetworkfamily-class.R#L444-L452). Specifically, `as.matrix(model$latent_network("support"))` errors because the latent network is `NULL` and thus cannot be converted to a matrix.

## The solution

I decided to modify the `PLNfamily$postTreatment()` method so that the call to each model's post-treatment is wrapped in a `tryCatch`. If it catches an error for model `i`, `PLNfamily$postTreatment()` emits a warning and then truncates the family to only include models `1` to `i - 1`.

Then, I extended the `postTreatment()` method to `PLNnetworkfamily` so that after calling the super-method, it also truncates the list of penalties accordingly.

For the `stability_selection()` in `PLNnetworkfamily` and `ZIPLNnetworkfamily`, if `Omega` is `NULL` on a subsample, then I interpret the entire network to be unstable at that sparsity, so I return a matrix of zeros.

I'm open to other solutions -- what matters to me is that I am able to run `PLNnetwork()` and `stability_selection()` without a complete crash midway through the grid of sparsities.

## Validation

I reinstalled a local build of the package and was able to call `PLNnetwork()` with the exact same data and parameters and get a result where it was previously crashing. I confirmed that the `PLNnetworkfamily` is correctly truncated and did not see other errors when I`print`ed it. I was also able to call `PLNnetwork()` on a second dataset where I only had an issue with `stability_selection()` (and not fitting on the whole data) and was able to get a result when it was previously crashing.

I don't run `PLNPCA()` so I haven't checked or modified `PLNPCAfamily` which also inherits from `PLNfamily`.